### PR TITLE
use the cache

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -15,6 +15,10 @@ steps:
     ]
 images: ['gcr.io/$PROJECT_ID/demo:latest']
 
+# This works in the local mode. The layers are cached properly, but not in the cloud build.
+#  - name: gcr.io/cloud-builders/docker
+#    args: ['build', '-t', 'gcr.io/$PROJECT_ID/demo', '-f', './docker/Dockerfile', '.']
+
 # need to get the build context to work properly. It doesn't seem to be trivial.
 #  - name: gcr.io/kaniko-project/executor:latest
 #    args:

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -1,5 +1,27 @@
 steps:
-  - name: gcr.io/cloud-builders/docker
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/demo', '-f', './docker/Dockerfile', '.']
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        docker pull gcr.io/$PROJECT_ID/demo:latest || exit 0
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [
+      'build',
+      '-t', 'gcr.io/$PROJECT_ID/demo:latest',
+      '--cache-from', 'gcr.io/$PROJECT_ID/demo:latest',
+      '-f', './docker/Dockerfile',
+      '.'
+    ]
+images: ['gcr.io/$PROJECT_ID/demo:latest']
 
-images: ['gcr.io/$PROJECT_ID/demo']
+# need to get the build context to work properly. It doesn't seem to be trivial.
+#  - name: gcr.io/kaniko-project/executor:latest
+#    args:
+#      - --destination=gcr.io/$PROJECT_ID/demo
+#      - --cache=true
+#      - --cache-ttl=24h
+#      - -f=./docker/Dockerfile
+#      - --context=git://github.com/zhongchen/gcp-demo.git#refs/heads/master
+#
+#images: ['gcr.io/$PROJECT_ID/demo']


### PR DESCRIPTION
Attempt to improve the docker image build time by leveraging caching.  